### PR TITLE
Implement POST /habits

### DIFF
--- a/habitipy/__init__.py
+++ b/habitipy/__init__.py
@@ -8,12 +8,21 @@ from .errors import (
     ServerError,
     UnexpectedResponseShapeError,
 )
-from .models.habits import Habit, HabitListPage, HabitType
+from .models.habits import (
+    GoalPeriodicity,
+    Habit,
+    HabitCreateRequest,
+    HabitListPage,
+    HabitType,
+    UnitSymbol,
+)
 
 __all__ = [
     "ApiError",
     "AuthenticationError",
+    "GoalPeriodicity",
     "Habit",
+    "HabitCreateRequest",
     "HabitListPage",
     "HabitType",
     "HabitipyClient",
@@ -21,5 +30,6 @@ __all__ = [
     "RateLimitError",
     "ResponseDecodeError",
     "ServerError",
+    "UnitSymbol",
     "UnexpectedResponseShapeError",
 ]

--- a/habitipy/habits.py
+++ b/habitipy/habits.py
@@ -5,7 +5,7 @@ from typing import Any
 import httpx
 
 from .errors import ResponseDecodeError, UnexpectedResponseShapeError, raise_for_api_status
-from .models.habits import HabitListPage, HabitListParams, HabitType
+from .models.habits import Habit, HabitCreateRequest, HabitListPage, HabitListParams, HabitType
 
 
 class HabitsResource:
@@ -34,6 +34,12 @@ class HabitsResource:
         raise_for_api_status(response)
         payload = _decode_json_object(response)
         return HabitListPage.model_validate(payload)
+
+    def create(self, request: HabitCreateRequest) -> Habit:
+        response = self._client.post("/habits", json=request.to_request_body())
+        raise_for_api_status(response)
+        payload = _decode_json_object(response)
+        return Habit.model_validate(payload)
 
 
 def _decode_json_object(response: httpx.Response) -> dict[str, Any]:

--- a/habitipy/models/__init__.py
+++ b/habitipy/models/__init__.py
@@ -1,3 +1,10 @@
-from .habits import Habit, HabitListPage, HabitType
+from .habits import GoalPeriodicity, Habit, HabitCreateRequest, HabitListPage, HabitType, UnitSymbol
 
-__all__ = ["Habit", "HabitListPage", "HabitType"]
+__all__ = [
+    "GoalPeriodicity",
+    "Habit",
+    "HabitCreateRequest",
+    "HabitListPage",
+    "HabitType",
+    "UnitSymbol",
+]

--- a/habitipy/models/habits.py
+++ b/habitipy/models/habits.py
@@ -92,9 +92,9 @@ class TimeTrigger(HabitModel):
 class HabitStack(HabitModel):
     id: str | None = None
     condition_habit_id: str = Field(alias="conditionHabitId")
-    type: str
-    timer_type: str = Field(alias="timerType")
-    timer_delay_secs: int = Field(alias="timerDelaySecs")
+    type: HabitStackTriggerType
+    timer_type: HabitStackTimerType = Field(alias="timerType")
+    timer_delay_secs: int | None = Field(default=None, alias="timerDelaySecs")
 
 
 class HabitCreateReminderTime(HabitModel):

--- a/habitipy/models/habits.py
+++ b/habitipy/models/habits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -59,6 +59,18 @@ class UnitSymbol(str, Enum):
     STEP = "step"
 
 
+class HabitStackTriggerType(str, Enum):
+    COMPLETED = "completed"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    REMINDER = "reminder"
+
+
+class HabitStackTimerType(str, Enum):
+    IMMEDIATELY = "immediately"
+    AFTER = "after"
+
+
 class ReminderTime(HabitModel):
     hour: int
     minute: int
@@ -85,6 +97,36 @@ class HabitStack(HabitModel):
     timer_delay_secs: int = Field(alias="timerDelaySecs")
 
 
+class HabitCreateReminderTime(HabitModel):
+    hour: int
+    minute: int
+
+
+class HabitCreateReminderOccurrenceFilter(HabitModel):
+    week_days: list[int] | None = Field(default=None, alias="weekDays")
+
+
+class HabitCreateTimeTrigger(HabitModel):
+    time: HabitCreateReminderTime
+    occurrence_filter: HabitCreateReminderOccurrenceFilter | None = Field(
+        default=None, alias="occurrenceFilter"
+    )
+    show_live_activity: bool | None = Field(default=None, alias="showLiveActivity")
+    show_as_alarm: bool | None = Field(default=None, alias="showAsAlarm")
+
+
+class HabitCreateHabitStack(HabitModel):
+    condition_habit_id: str = Field(alias="conditionHabitId")
+    type: HabitStackTriggerType
+    timer_type: HabitStackTimerType = Field(alias="timerType")
+    timer_delay_secs: int | None = Field(default=None, alias="timerDelaySecs")
+
+
+class HabitCreateReminders(HabitModel):
+    time_triggers: list[HabitCreateTimeTrigger] = Field(default_factory=list, alias="timeTriggers")
+    habit_stacks: list[HabitCreateHabitStack] = Field(default_factory=list, alias="habitStacks")
+
+
 class Reminders(HabitModel):
     time_triggers: list[TimeTrigger] = Field(default_factory=list, alias="timeTriggers")
     habit_stacks: list[HabitStack] = Field(default_factory=list, alias="habitStacks")
@@ -109,8 +151,36 @@ class IntervalDaysOccurrence(HabitModel):
     interval: int
 
 
+class HabitCreateDailyOccurrence(HabitModel):
+    type: Literal["daily"]
+
+
+class HabitCreateWeekDaysOccurrence(HabitModel):
+    type: Literal["weekDays"]
+    days: list[int]
+
+
+class HabitCreateMonthDaysOccurrence(HabitModel):
+    type: Literal["monthDays"]
+    days: list[int]
+
+
+class HabitCreateIntervalDaysOccurrence(HabitModel):
+    type: Literal["intervalDays"]
+    interval: int
+
+
 Occurrence = Annotated[
     DailyOccurrence | WeekDaysOccurrence | MonthDaysOccurrence | IntervalDaysOccurrence,
+    Field(discriminator="type"),
+]
+
+
+HabitCreateOccurrence = Annotated[
+    HabitCreateDailyOccurrence
+    | HabitCreateWeekDaysOccurrence
+    | HabitCreateMonthDaysOccurrence
+    | HabitCreateIntervalDaysOccurrence,
     Field(discriminator="type"),
 ]
 
@@ -149,10 +219,45 @@ class TotalLogValueEndCondition(HabitModel):
     total_log_value: float = Field(alias="totalLogValue")
 
 
+class HabitCreateDateEndCondition(HabitModel):
+    type: Literal["date"]
+    date: date
+
+
+class HabitCreateStreakEndCondition(HabitModel):
+    type: Literal["streak"]
+    streak_length: int = Field(alias="streakLength")
+
+
+class HabitCreateSuccessPeriodsEndCondition(HabitModel):
+    type: Literal["successPeriods"]
+    total_periods: int = Field(alias="totalPeriods")
+
+
+class HabitCreateTotalLogValueEndCondition(HabitModel):
+    type: Literal["totalLogValue"]
+    total_log_value: float = Field(alias="totalLogValue")
+
+
 EndCondition = Annotated[
     DateEndCondition | StreakEndCondition | SuccessPeriodsEndCondition | TotalLogValueEndCondition,
     Field(discriminator="type"),
 ]
+
+
+HabitCreateEndCondition = Annotated[
+    HabitCreateDateEndCondition
+    | HabitCreateStreakEndCondition
+    | HabitCreateSuccessPeriodsEndCondition
+    | HabitCreateTotalLogValueEndCondition,
+    Field(discriminator="type"),
+]
+
+
+class HabitCreateGoal(HabitModel):
+    periodicity: GoalPeriodicity
+    value: float
+    unit: UnitSymbol
 
 
 class Goal(HabitModel):
@@ -206,6 +311,28 @@ class Habit(HabitModel):
 class HabitListPage(HabitModel):
     data: list[Habit]
     pagination: Pagination
+
+
+class HabitCreateRequest(HabitModel):
+    name: str
+    type: HabitType
+    description: str | None = None
+    occurrence: HabitCreateOccurrence | None = None
+    start_date: date | None = Field(default=None, alias="startDate")
+    icon: str | None = None
+    color_hex: str | None = Field(default=None, alias="colorHex")
+    custom_unit_name: str | None = Field(default=None, alias="customUnitName")
+    area_ids: list[str] | None = Field(default=None, alias="areaIds")
+    time_of_day_ids: list[str] | None = Field(default=None, alias="timeOfDayIds")
+    goal: HabitCreateGoal | None = None
+    reminders: HabitCreateReminders | None = None
+    end_condition: HabitCreateEndCondition | None = Field(default=None, alias="endCondition")
+
+    def to_request_body(self) -> dict[str, object]:
+        return cast(
+            dict[str, object],
+            self.model_dump(by_alias=True, exclude_none=True, mode="json"),
+        )
 
 
 class HabitListParams(HabitModel):

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -54,7 +54,14 @@ def build_habits_payload() -> dict[str, object]:
                             "showAsAlarm": False,
                         }
                     ],
-                    "habitStacks": [],
+                    "habitStacks": [
+                        {
+                            "id": "stack_1",
+                            "conditionHabitId": "habit_456",
+                            "type": "completed",
+                            "timerType": "immediately",
+                        }
+                    ],
                 },
                 "endCondition": None,
                 "goals": [
@@ -129,6 +136,9 @@ def test_client_habits_list_sends_expected_query_params_and_parses_response() ->
     assert page.pagination.total == 1
     assert page.data[0].type is HabitType.GOOD
     assert page.data[0].time_of_days[0].name == "Morning"
+    assert page.data[0].reminders.habit_stacks[0].type is HabitStackTriggerType.COMPLETED
+    assert page.data[0].reminders.habit_stacks[0].timer_type is HabitStackTimerType.IMMEDIATELY
+    assert page.data[0].reminders.habit_stacks[0].timer_delay_secs is None
 
 
 @respx.mock
@@ -205,6 +215,9 @@ def test_client_habits_create_sends_expected_json_and_parses_response() -> None:
     assert habit.id == "habit_123"
     assert habit.name == "Morning Run"
     assert habit.type is HabitType.GOOD
+    assert habit.reminders.habit_stacks[0].type is HabitStackTriggerType.COMPLETED
+    assert habit.reminders.habit_stacks[0].timer_type is HabitStackTimerType.IMMEDIATELY
+    assert habit.reminders.habit_stacks[0].timer_delay_secs is None
 
 
 @respx.mock

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
+from pydantic import ValidationError
 
-from habitipy import HabitipyClient, HabitType
+from habitipy import GoalPeriodicity, HabitCreateRequest, HabitipyClient, HabitType, UnitSymbol
 from habitipy.errors import (
     ApiError,
+    AuthenticationError,
     RateLimitError,
     ResponseDecodeError,
     UnexpectedResponseShapeError,
+)
+from habitipy.models.habits import (
+    HabitCreateDateEndCondition,
+    HabitCreateGoal,
+    HabitCreateHabitStack,
+    HabitCreateReminderOccurrenceFilter,
+    HabitCreateReminders,
+    HabitCreateReminderTime,
+    HabitCreateTimeTrigger,
+    HabitCreateWeekDaysOccurrence,
+    HabitStackTimerType,
+    HabitStackTriggerType,
 )
 
 
@@ -78,6 +94,10 @@ def build_habits_payload() -> dict[str, object]:
     }
 
 
+def build_habit_payload() -> dict[str, object]:
+    return dict(build_habits_payload()["data"][0])
+
+
 @respx.mock
 def test_client_habits_list_sends_expected_query_params_and_parses_response() -> None:
     route = respx.get("https://api.habitify.me/v2/habits").mock(
@@ -112,6 +132,82 @@ def test_client_habits_list_sends_expected_query_params_and_parses_response() ->
 
 
 @respx.mock
+def test_client_habits_create_sends_expected_json_and_parses_response() -> None:
+    route = respx.post("https://api.habitify.me/v2/habits").mock(
+        return_value=httpx.Response(201, json=build_habit_payload())
+    )
+
+    request = HabitCreateRequest(
+        name="Morning Run",
+        type=HabitType.GOOD,
+        description="Run before breakfast",
+        occurrence=HabitCreateWeekDaysOccurrence(type="weekDays", days=[2, 3, 4, 5, 6]),
+        startDate="2024-01-01",
+        icon="figure.run",
+        colorHex="#FF6B6B",
+        customUnitName="laps",
+        areaIds=["area_1"],
+        timeOfDayIds=["tod_1"],
+        goal=HabitCreateGoal(
+            periodicity=GoalPeriodicity.DAILY,
+            value=5,
+            unit=UnitSymbol.KM,
+        ),
+        reminders=HabitCreateReminders(
+            timeTriggers=[
+                HabitCreateTimeTrigger(
+                    time=HabitCreateReminderTime(hour=6, minute=30),
+                    occurrenceFilter=HabitCreateReminderOccurrenceFilter(weekDays=[2, 3, 4]),
+                    showLiveActivity=True,
+                    showAsAlarm=False,
+                )
+            ],
+            habitStacks=[
+                HabitCreateHabitStack(
+                    conditionHabitId="habit_abc",
+                    type=HabitStackTriggerType.COMPLETED,
+                    timerType=HabitStackTimerType.AFTER,
+                    timerDelaySecs=300,
+                )
+            ],
+        ),
+        endCondition=HabitCreateDateEndCondition(type="date", date="2024-12-31"),
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        habit = client.habits.create(request)
+    finally:
+        client.close()
+
+    http_request = route.calls[0].request
+    assert http_request.headers["X-API-Key"] == "test-key"
+
+    payload = json.loads(http_request.content.decode("utf-8"))
+    assert payload["name"] == "Morning Run"
+    assert payload["type"] == "good"
+    assert payload["occurrence"] == {"type": "weekDays", "days": [2, 3, 4, 5, 6]}
+    assert payload["startDate"] == "2024-01-01"
+    assert payload["colorHex"] == "#FF6B6B"
+    assert payload["customUnitName"] == "laps"
+    assert payload["areaIds"] == ["area_1"]
+    assert payload["timeOfDayIds"] == ["tod_1"]
+    assert payload["goal"] == {"periodicity": "daily", "value": 5.0, "unit": "kM"}
+    assert payload["endCondition"] == {"type": "date", "date": "2024-12-31"}
+    assert payload["reminders"]["timeTriggers"][0]["occurrenceFilter"] == {"weekDays": [2, 3, 4]}
+    assert payload["reminders"]["habitStacks"][0] == {
+        "conditionHabitId": "habit_abc",
+        "type": "completed",
+        "timerType": "after",
+        "timerDelaySecs": 300,
+    }
+
+    assert habit.id == "habit_123"
+    assert habit.name == "Morning Run"
+    assert habit.type is HabitType.GOOD
+
+
+@respx.mock
 def test_client_habits_list_uses_injected_httpx_client() -> None:
     route = respx.get("https://api.habitify.me/v2/habits").mock(
         return_value=httpx.Response(200, json=build_habits_payload())
@@ -125,6 +221,11 @@ def test_client_habits_list_uses_injected_httpx_client() -> None:
 
     assert route.calls[0].request.headers["X-API-Key"] == "injected-key"
     assert page.data[0].name == "Morning Run"
+
+
+def test_habit_create_request_requires_name_and_type() -> None:
+    with pytest.raises(ValidationError):
+        HabitCreateRequest()  # type: ignore[call-arg]
 
 
 @respx.mock
@@ -172,6 +273,34 @@ def test_client_habits_list_uses_generic_api_error_for_bad_request() -> None:
         client.close()
 
     assert exc_info.value.response.status_code == 400
+
+
+@respx.mock
+def test_client_habits_create_maps_bad_request_error() -> None:
+    respx.post("https://api.habitify.me/v2/habits").mock(
+        return_value=httpx.Response(400, json={"message": "Request validation failed"})
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        with pytest.raises(ApiError, match="Request validation failed"):
+            client.habits.create(HabitCreateRequest(name="Morning Run", type=HabitType.GOOD))
+    finally:
+        client.close()
+
+
+@respx.mock
+def test_client_habits_create_maps_authentication_error() -> None:
+    respx.post("https://api.habitify.me/v2/habits").mock(
+        return_value=httpx.Response(401, json={"message": "Missing API key"})
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        with pytest.raises(AuthenticationError, match="Missing API key"):
+            client.habits.create(HabitCreateRequest(name="Morning Run", type=HabitType.GOOD))
+    finally:
+        client.close()
 
 
 @respx.mock
@@ -232,5 +361,23 @@ def test_client_habits_list_raises_response_decode_error_for_invalid_json() -> N
     try:
         with pytest.raises(ResponseDecodeError, match="invalid JSON"):
             client.habits.list()
+    finally:
+        client.close()
+
+
+@respx.mock
+def test_client_habits_create_raises_response_decode_error_for_invalid_json() -> None:
+    respx.post("https://api.habitify.me/v2/habits").mock(
+        return_value=httpx.Response(
+            201,
+            content=b"not-json",
+            headers={"Content-Type": "application/json"},
+        )
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        with pytest.raises(ResponseDecodeError, match="invalid JSON"):
+            client.habits.create(HabitCreateRequest(name="Morning Run", type=HabitType.GOOD))
     finally:
         client.close()


### PR DESCRIPTION
## Summary
- add a typed `HabitsResource.create()` client for `POST /habits`
- model create-only request payloads separately from read-side `Habit` responses
- cover request serialization, validation, error mapping, and invalid JSON handling in focused tests

## Validation
- poetry run isort habitipy tests
- poetry run black habitipy tests
- poetry run ruff check habitipy tests
- poetry run mypy habitipy
- poetry run pytest tests/test_habits.py
- poetry run tox run -e quality
- poetry run tox run -e py310,py311,py312,py313

Closes #2