### PR TITLE
Implement remaining Habitify API endpoints and coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   quality:
@@ -71,3 +72,31 @@ jobs:
 
       - name: Run tests in tox
         run: poetry run tox run -e ${{ matrix.tox-env }}
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: python -m pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --extras dev
+
+      - name: Generate coverage report
+        run: poetry run pytest --cov=habitipy --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   quality:
@@ -76,6 +75,9 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out repository
@@ -99,4 +101,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           use_oidc: true

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For a quick coverage report:
 poetry run pytest --cov=habitipy --cov-report=term-missing
 ```
 
-Coverage uploads run from the `Coverage` GitHub Actions job and power the README badge via Codecov. If tokenless uploads are unavailable for the repository, configure `CODECOV_TOKEN` in repository secrets.
+Coverage uploads run from the `Coverage` GitHub Actions job and power the README badge via Codecov. The workflow uses OIDC by default and also passes `CODECOV_TOKEN` when that secret is configured, so repositories that require the token can opt in without changing the workflow.
 
 For the declared support matrix, use `tox`:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # habitipy
+[![Coverage](https://codecov.io/gh/ReiRev/habitipy/branch/main/graph/badge.svg)](https://codecov.io/gh/ReiRev/habitipy)
+
 A Python client for Habitify: manage habits, logs, completions, skips, and progress from code.
 
 ## Usage
@@ -76,6 +78,8 @@ For a quick coverage report:
 ```bash
 poetry run pytest --cov=habitipy --cov-report=term-missing
 ```
+
+Coverage uploads run from the `Coverage` GitHub Actions job and power the README badge via Codecov. If tokenless uploads are unavailable for the repository, configure `CODECOV_TOKEN` in repository secrets.
 
 For the declared support matrix, use `tox`:
 

--- a/habitipy/__init__.py
+++ b/habitipy/__init__.py
@@ -10,7 +10,10 @@ from .errors import (
 )
 from .models.habits import (
     Area,
+    AreaCreateRequest,
     AreaListResponse,
+    AreaResponse,
+    AreaUpdateRequest,
     GoalPeriodicity,
     Habit,
     HabitCreateRequest,
@@ -38,7 +41,10 @@ from .models.habits import (
 
 __all__ = [
     "Area",
+    "AreaCreateRequest",
     "AreaListResponse",
+    "AreaResponse",
+    "AreaUpdateRequest",
     "ApiError",
     "AuthenticationError",
     "GoalPeriodicity",

--- a/habitipy/areas.py
+++ b/habitipy/areas.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from urllib.parse import quote
+
 import httpx
 
 from ._json import decode_json_object
 from .errors import raise_for_api_status
-from .models.habits import AreaListResponse
+from .models.habits import (
+    Area,
+    AreaCreateRequest,
+    AreaListResponse,
+    AreaResponse,
+    AreaUpdateRequest,
+)
 
 
 class AreasResource:
@@ -16,3 +24,38 @@ class AreasResource:
         raise_for_api_status(response)
         payload = decode_json_object(response)
         return AreaListResponse.model_validate(payload)
+
+    def get(self, area_id: str) -> Area:
+        response = self._client.get(f"/areas/{_quote_path_value(area_id)}")
+        raise_for_api_status(response)
+        payload = decode_json_object(response)
+        return AreaResponse.model_validate(payload).data
+
+    def create(self, request: AreaCreateRequest) -> Area:
+        response = self._client.post("/areas", json=request.to_request_body())
+        raise_for_api_status(response)
+        payload = decode_json_object(response)
+        return AreaResponse.model_validate(payload).data
+
+    def update(self, area_id: str, request: AreaUpdateRequest) -> Area:
+        response = self._client.put(
+            f"/areas/{_quote_path_value(area_id)}",
+            json=request.to_request_body(),
+        )
+        raise_for_api_status(response)
+        payload = decode_json_object(response)
+        return AreaResponse.model_validate(payload).data
+
+    def delete(self, area_id: str) -> None:
+        response = self._client.delete(f"/areas/{_quote_path_value(area_id)}")
+        raise_for_api_status(response)
+        if response.status_code != 204:
+            raise httpx.HTTPStatusError(
+                f"Expected HTTP 204 No Content for area deletion, got {response.status_code}.",
+                request=response.request,
+                response=response,
+            )
+
+
+def _quote_path_value(value: str) -> str:
+    return quote(value, safe="")

--- a/habitipy/models/__init__.py
+++ b/habitipy/models/__init__.py
@@ -1,6 +1,9 @@
 from .habits import (
     Area,
+    AreaCreateRequest,
     AreaListResponse,
+    AreaResponse,
+    AreaUpdateRequest,
     GoalPeriodicity,
     Habit,
     HabitCreateRequest,
@@ -28,7 +31,10 @@ from .habits import (
 
 __all__ = [
     "Area",
+    "AreaCreateRequest",
     "AreaListResponse",
+    "AreaResponse",
+    "AreaUpdateRequest",
     "GoalPeriodicity",
     "Habit",
     "HabitCreateRequest",

--- a/habitipy/models/habits.py
+++ b/habitipy/models/habits.py
@@ -300,8 +300,36 @@ class Area(HabitModel):
     description: str | None = None
 
 
+class AreaResponse(HabitModel):
+    data: Area
+
+
 class AreaListResponse(HabitModel):
     data: list[Area]
+
+
+class AreaCreateRequest(HabitModel):
+    name: str
+    color_hex: str | None = Field(default=None, alias="colorHex")
+    icon: str | None = None
+
+    def to_request_body(self) -> dict[str, object]:
+        return cast(
+            dict[str, object],
+            self.model_dump(by_alias=True, exclude_none=True, mode="json"),
+        )
+
+
+class AreaUpdateRequest(HabitModel):
+    name: str | None = None
+    color_hex: str | None = Field(default=None, alias="colorHex")
+    icon: str | None = None
+
+    def to_request_body(self) -> dict[str, object]:
+        return cast(
+            dict[str, object],
+            self.model_dump(by_alias=True, exclude_none=True, mode="json"),
+        )
 
 
 class TimeOfDay(HabitModel):

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -4,8 +4,13 @@ import httpx
 import pytest
 import respx
 
-from habitipy import AreaListResponse, HabitipyClient
-from habitipy.errors import AuthenticationError, ResponseDecodeError, UnexpectedResponseShapeError
+from habitipy import AreaCreateRequest, AreaListResponse, AreaUpdateRequest, HabitipyClient
+from habitipy.errors import (
+    AuthenticationError,
+    NotFoundError,
+    ResponseDecodeError,
+    UnexpectedResponseShapeError,
+)
 
 
 def build_areas_payload() -> dict[str, object]:
@@ -21,6 +26,10 @@ def build_areas_payload() -> dict[str, object]:
             }
         ]
     }
+
+
+def build_area_payload() -> dict[str, object]:
+    return {"data": build_areas_payload()["data"][0]}
 
 
 @respx.mock
@@ -41,6 +50,107 @@ def test_client_areas_list_parses_response() -> None:
 
 
 @respx.mock
+def test_client_areas_get_parses_response() -> None:
+    route = respx.get("https://api.habitify.me/v2/areas/area_1").mock(
+        return_value=httpx.Response(200, json=build_area_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        area = client.areas.get("area_1")
+    finally:
+        client.close()
+
+    assert route.called
+    assert area.id == "area_1"
+    assert area.name == "Health"
+
+
+@respx.mock
+def test_client_areas_get_url_encodes_path_segment() -> None:
+    route = respx.get("https://api.habitify.me/v2/areas/area%2Fwith%20spaces%3F%23").mock(
+        return_value=httpx.Response(200, json=build_area_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        area = client.areas.get("area/with spaces?#")
+    finally:
+        client.close()
+
+    assert route.called
+    assert route.calls[0].request.url.raw_path == b"/v2/areas/area%2Fwith%20spaces%3F%23"
+    assert area.id == "area_1"
+
+
+@respx.mock
+def test_client_areas_create_sends_expected_json_and_parses_response() -> None:
+    route = respx.post("https://api.habitify.me/v2/areas").mock(
+        return_value=httpx.Response(201, json=build_area_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        area = client.areas.create(
+            AreaCreateRequest(name="Health", color_hex="#4ECDC4", icon="heart")
+        )
+    finally:
+        client.close()
+
+    assert route.called
+    assert route.calls[0].request.headers["X-API-Key"] == "test-key"
+    assert route.calls[0].request.read().decode("utf-8") == (
+        '{"name":"Health","colorHex":"#4ECDC4","icon":"heart"}'
+    )
+    assert area.id == "area_1"
+
+
+@respx.mock
+def test_client_areas_update_sends_only_provided_fields_and_parses_response() -> None:
+    route = respx.put("https://api.habitify.me/v2/areas/area_1").mock(
+        return_value=httpx.Response(200, json=build_area_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        area = client.areas.update("area_1", AreaUpdateRequest(name="Wellness"))
+    finally:
+        client.close()
+
+    assert route.called
+    assert route.calls[0].request.read().decode("utf-8") == '{"name":"Wellness"}'
+    assert area.name == "Health"
+
+
+@respx.mock
+def test_client_areas_delete_returns_none_on_204() -> None:
+    route = respx.delete("https://api.habitify.me/v2/areas/area_1").mock(
+        return_value=httpx.Response(204)
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        result = client.areas.delete("area_1")
+    finally:
+        client.close()
+
+    assert route.called
+    assert result is None
+
+
+@respx.mock
+def test_client_areas_delete_rejects_unexpected_success_status() -> None:
+    respx.delete("https://api.habitify.me/v2/areas/area_1").mock(return_value=httpx.Response(200))
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        with pytest.raises(httpx.HTTPStatusError, match="Expected HTTP 204 No Content"):
+            client.areas.delete("area_1")
+    finally:
+        client.close()
+
+
+@respx.mock
 def test_client_areas_list_maps_authentication_error() -> None:
     respx.get("https://api.habitify.me/v2/areas").mock(
         return_value=httpx.Response(401, json={"message": "Missing API key"})
@@ -50,6 +160,20 @@ def test_client_areas_list_maps_authentication_error() -> None:
     try:
         with pytest.raises(AuthenticationError, match="Missing API key"):
             client.areas.list()
+    finally:
+        client.close()
+
+
+@respx.mock
+def test_client_areas_get_maps_not_found_error() -> None:
+    respx.get("https://api.habitify.me/v2/areas/missing").mock(
+        return_value=httpx.Response(404, json={"message": "Area not found"})
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        with pytest.raises(NotFoundError, match="Area not found"):
+            client.areas.get("missing")
     finally:
         client.close()
 

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -99,9 +101,11 @@ def test_client_areas_create_sends_expected_json_and_parses_response() -> None:
 
     assert route.called
     assert route.calls[0].request.headers["X-API-Key"] == "test-key"
-    assert route.calls[0].request.read().decode("utf-8") == (
-        '{"name":"Health","colorHex":"#4ECDC4","icon":"heart"}'
-    )
+    assert json.loads(route.calls[0].request.content.decode("utf-8")) == {
+        "name": "Health",
+        "colorHex": "#4ECDC4",
+        "icon": "heart",
+    }
     assert area.id == "area_1"
 
 
@@ -118,7 +122,7 @@ def test_client_areas_update_sends_only_provided_fields_and_parses_response() ->
         client.close()
 
     assert route.called
-    assert route.calls[0].request.read().decode("utf-8") == '{"name":"Wellness"}'
+    assert json.loads(route.calls[0].request.content.decode("utf-8")) == {"name": "Wellness"}
     assert area.name == "Health"
 
 


### PR DESCRIPTION
## Summary
- add typed support for habit log, note, and area endpoints, including full area CRUD via client.areas.*
- extract the shared JSON object decoder used by resources and add focused regression tests for the reviewed behaviors
- add a coverage publishing workflow and README coverage badge backed by Codecov

## Validation
- poetry run pytest tests/test_habits.py tests/test_areas.py
- poetry run pytest --cov=habitipy --cov-report=xml
- poetry run isort habitipy tests
- poetry run black habitipy tests
- poetry run ruff check habitipy tests
- poetry run mypy habitipy
- poetry run tox run -e py310,py311,py312,py313

## Issues
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24