### PR TITLE
Fix live read endpoint response parsing

### DIFF
--- a/habitipy/habits.py
+++ b/habitipy/habits.py
@@ -21,6 +21,7 @@ from .models.habits import (
     HabitNoteCreateRequest,
     HabitNoteListResponse,
     HabitNoteUpdateRequest,
+    HabitResponse,
     HabitStatisticsParams,
     HabitStatisticsResponse,
     HabitType,
@@ -37,6 +38,8 @@ class HabitsResource:
         response = self._client.get(f"/habits/{_quote_path_value(habit_id)}")
         raise_for_api_status(response)
         payload = decode_json_object(response)
+        if isinstance(payload.get("data"), dict):
+            return HabitResponse.model_validate(payload).data
         return Habit.model_validate(payload)
 
     def list(

--- a/habitipy/models/habits.py
+++ b/habitipy/models/habits.py
@@ -414,7 +414,7 @@ class HabitJournalPage(HabitModel):
 class HabitStatisticsUnit(HabitModel):
     id: str | None = None
     name: str | None = None
-    symbol: UnitSymbol | str | None = None
+    symbol: UnitSymbol | str
 
     @field_validator("symbol", mode="before")
     @classmethod

--- a/habitipy/models/habits.py
+++ b/habitipy/models/habits.py
@@ -412,9 +412,9 @@ class HabitJournalPage(HabitModel):
 
 
 class HabitStatisticsUnit(HabitModel):
-    id: str
-    name: str
-    symbol: UnitSymbol | str
+    id: str | None = None
+    name: str | None = None
+    symbol: UnitSymbol | str | None = None
 
     @field_validator("symbol", mode="before")
     @classmethod
@@ -451,6 +451,10 @@ class HabitStatistics(HabitModel):
 
 class HabitStatisticsResponse(HabitModel):
     data: HabitStatistics
+
+
+class HabitResponse(HabitModel):
+    data: Habit
 
 
 class SuccessMessageResponse(HabitModel):

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -126,6 +126,10 @@ def build_habit_payload() -> dict[str, object]:
     return dict(build_habits_payload()["data"][0])
 
 
+def build_habit_response_payload() -> dict[str, object]:
+    return {"data": build_habit_payload()}
+
+
 def build_habit_journal_payload() -> dict[str, object]:
     return {
         "data": [
@@ -175,6 +179,12 @@ def build_habit_statistics_payload() -> dict[str, object]:
     }
 
 
+def build_habit_statistics_live_unit_payload() -> dict[str, object]:
+    payload = build_habit_statistics_payload()
+    payload["data"]["unit"] = {"symbol": UnitSymbol.REP.value, "type": "scalar"}
+    return payload
+
+
 def build_habit_log_response_payload() -> dict[str, object]:
     return {"message": "Habit log created successfully"}
 
@@ -218,6 +228,22 @@ def test_client_habits_get_sends_expected_path_and_parses_response() -> None:
 
 
 @respx.mock
+def test_client_habits_get_parses_enveloped_response() -> None:
+    respx.get("https://api.habitify.me/v2/habits/habit_123").mock(
+        return_value=httpx.Response(200, json=build_habit_response_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        habit = client.habits.get("habit_123")
+    finally:
+        client.close()
+
+    assert habit.id == "habit_123"
+    assert habit.type is HabitType.GOOD
+
+
+@respx.mock
 def test_client_habits_get_url_encodes_path_segment() -> None:
     route = respx.get("https://api.habitify.me/v2/habits/habit%2Fwith%20spaces%3F%23").mock(
         return_value=httpx.Response(200, json=build_habit_payload())
@@ -232,6 +258,23 @@ def test_client_habits_get_url_encodes_path_segment() -> None:
     assert route.called
     assert route.calls[0].request.url.raw_path == b"/v2/habits/habit%2Fwith%20spaces%3F%23"
     assert habit.id == "habit_123"
+
+
+@respx.mock
+def test_client_habits_statistics_parses_live_unit_shape_without_id_or_name() -> None:
+    respx.get("https://api.habitify.me/v2/habits/habit_123/statistics").mock(
+        return_value=httpx.Response(200, json=build_habit_statistics_live_unit_payload())
+    )
+
+    client = HabitipyClient(api_key="test-key")
+    try:
+        statistics = client.habits.statistics("habit_123")
+    finally:
+        client.close()
+
+    assert statistics.data.unit.id is None
+    assert statistics.data.unit.name is None
+    assert statistics.data.unit.symbol is UnitSymbol.REP
 
 
 @respx.mock

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -229,7 +229,7 @@ def test_client_habits_get_sends_expected_path_and_parses_response() -> None:
 
 @respx.mock
 def test_client_habits_get_parses_enveloped_response() -> None:
-    respx.get("https://api.habitify.me/v2/habits/habit_123").mock(
+    route = respx.get("https://api.habitify.me/v2/habits/habit_123").mock(
         return_value=httpx.Response(200, json=build_habit_response_payload())
     )
 
@@ -239,6 +239,9 @@ def test_client_habits_get_parses_enveloped_response() -> None:
     finally:
         client.close()
 
+    assert route.called
+    assert route.calls[0].request.url.path == "/v2/habits/habit_123"
+    assert route.calls[0].request.headers["X-API-Key"] == "test-key"
     assert habit.id == "habit_123"
     assert habit.type is HabitType.GOOD
 
@@ -262,7 +265,7 @@ def test_client_habits_get_url_encodes_path_segment() -> None:
 
 @respx.mock
 def test_client_habits_statistics_parses_live_unit_shape_without_id_or_name() -> None:
-    respx.get("https://api.habitify.me/v2/habits/habit_123/statistics").mock(
+    route = respx.get("https://api.habitify.me/v2/habits/habit_123/statistics").mock(
         return_value=httpx.Response(200, json=build_habit_statistics_live_unit_payload())
     )
 
@@ -272,6 +275,9 @@ def test_client_habits_statistics_parses_live_unit_shape_without_id_or_name() ->
     finally:
         client.close()
 
+    assert route.called
+    assert route.calls[0].request.url.path == "/v2/habits/habit_123/statistics"
+    assert route.calls[0].request.headers["X-API-Key"] == "test-key"
     assert statistics.data.unit.id is None
     assert statistics.data.unit.name is None
     assert statistics.data.unit.symbol is UnitSymbol.REP


### PR DESCRIPTION
## Summary
- accept the live enveloped response shape returned by GET /habits/{habitId}
- relax habit statistics unit parsing to handle the live unit payload returned by the API
- add focused regression tests covering the live read response shapes

## Validation
- poetry run pytest tests/test_habits.py
- poetry run isort habitipy tests
- poetry run black habitipy tests
- poetry run ruff check habitipy tests
- poetry run mypy habitipy

Follow-up to #35 after merge.