### PR TITLE
Add typed package metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/habitipie
+      url: https://pypi.org/project/habitipie/
 
     permissions:
       id-token: write

--- a/habitipie/py.typed
+++ b/habitipie/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 typed package support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Python client for Habitify: manage habits, logs, completions, s
 authors = [
     {name = "ReiRev",email = "reirev2913@gmail.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
@@ -19,6 +19,13 @@ dependencies = [
     "httpx>=0.27,<1",
     "pydantic>=2.8,<3",
 ]
+
+
+[project.urls]
+Homepage = "https://github.com/ReiRev/habitipie"
+Repository = "https://github.com/ReiRev/habitipie"
+Issues = "https://github.com/ReiRev/habitipie/issues"
+Documentation = "https://github.com/ReiRev/habitipie#readme"
 
 
 [project.optional-dependencies]
@@ -88,6 +95,13 @@ skip_covered = true
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]
+
+
+[tool.poetry]
+include = [
+    { path = "habitipie/py.typed", format = "sdist" },
+    { path = "habitipie/py.typed", format = "wheel" },
+]
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `habitipie/py.typed` so type checkers can consume the published package as typed
- add PyPI project URLs and switch the license metadata to the modern string form
- fix the release workflow PyPI project URL

## Validation
- poetry check
- python -m build
- inspected built wheel and sdist to confirm `habitipie/py.typed` is included
- inspected built wheel metadata to confirm Project-URL entries and `License-Expression: MIT`